### PR TITLE
add mobile-detect missing dep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "express-user-management",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -552,6 +552,11 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.3.tgz",
       "integrity": "sha512-+bMdgqjMN/Z77a6NlY/I3U5LlRDbnmaAk6lDveAPKwSpcPM4tKAuYsvYF8xjhOPXhOYGe/73vVLVez5PW+jqhw==",
       "dev": true
+    },
+    "mobile-detect": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/mobile-detect/-/mobile-detect-1.4.4.tgz",
+      "integrity": "sha512-vTgEjKjS89C5yHL5qWPpT6BzKuOVqABp+A3Szpbx34pIy3sngxlGaFpgHhfj6fKze1w0QKeOSDbU7SKu7wDvRQ=="
     },
     "mongodb": {
       "version": "3.2.2",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "handlebars": "^4.3.3",
     "jsonwebtoken": "^8.5.1",
     "lodash.set": "^4.3.2",
+    "mobile-detect": "^1.4.4",
     "mongodb": "^3.2.2",
     "nodemailer": "^6.0.0",
     "passport": "^0.4.0",


### PR DESCRIPTION
In `node_modules/express-user-management/src/adapters/passport-mongo/routes/login.js` :

`const MobileDetect = require('mobile-detect');`

But "mobile-detect" module is not included in dependencies