### PR TITLE
allow options in mongodb url

### DIFF
--- a/src/adapters/passport-mongo/db.js
+++ b/src/adapters/passport-mongo/db.js
@@ -18,8 +18,9 @@ const dbObject = {
           reject(err.toString());
         } else {
           const urlSplit = options.mongoUrl.split('/');
-          console.log("Connected successfully to server", urlSplit[urlSplit.length - 1]);
-          db = client.db(urlSplit[urlSplit.length - 1]);
+          const databaseName = urlSplit[urlSplit.length - 1].split('?')[0]
+          console.log("Connected successfully to database", databaseName);
+          db = client.db(databaseName);
           dbObject.db = db;
           resolve(db);
         }


### PR DESCRIPTION
Voir explications complètes ici: https://github.com/gwenaelp/express-user-management/pull/20

A ce jour pour la chaine suivante: `mongodb://example1.com,example2.com,example3.com/pouet?replicaSet=test&readPreference=secondary`

le nom de la base déduit par le code est `pouet?replicaSet=test&readPreference=secondary` au lieu de `pouet`; ce qui fait la planter la connexion.




